### PR TITLE
feat(career): implement interactive career timeline section

### DIFF
--- a/src/components/sections/Career.astro
+++ b/src/components/sections/Career.astro
@@ -1,0 +1,90 @@
+---
+// src/sections/Career.astro
+import { getCollection, type CollectionEntry } from 'astro:content';
+import ExperienceCard from '@/components/ui/ExperienceCard.astro';
+
+const allCareerItems: CollectionEntry<'career'>[] =
+  await getCollection('career');
+allCareerItems.sort(
+  (a, b) => b.data.startDate.valueOf() - a.data.startDate.valueOf()
+);
+---
+
+<section id="experience" class="py-24 md:py-32">
+  <div class="container-narrow career-section-content">
+    <h2 class="mb-16 text-center text-h2 font-bold text-text-primary">
+      // Carrera Profesional
+    </h2>
+
+    <div class="relative">
+      <!-- 
+        LA CORRECCIÓN ARQUITECTÓNICA:
+        - `top-4 bottom-4`: En lugar de `h-full`, estiramos la línea desde un
+          punto cercano al principio hasta un punto cercano al final del contenedor.
+        - Esto asegura que la línea siempre tenga una altura visible, incluso si
+          el contenedor cambia de tamaño, y le da un "aire" en los extremos.
+      -->
+      <div
+        class="timeline-line absolute bottom-4 left-1/2 top-4 w-px -translate-x-1/2 bg-border"
+      >
+      </div>
+
+      <div class="space-y-16">
+        {
+          allCareerItems.map((item, index) => (
+            <div class="timeline-item relative flex items-center">
+              <div class="timeline-node absolute left-1/2 h-3 w-3 -translate-x-1/2 rounded-full border-2 border-border bg-background" />
+              <div
+                class:list={[
+                  'w-full px-4 md:w-[calc(50%-2rem)]',
+                  {
+                    'md:ml-auto md:pl-0': index % 2 !== 0,
+                    'md:pr-0': index % 2 === 0,
+                  },
+                ]}
+              >
+                <ExperienceCard experience={item} />
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  import gsap from 'gsap';
+  import { ScrollTrigger } from 'gsap/ScrollTrigger';
+  gsap.registerPlugin(ScrollTrigger);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const section = document.querySelector('.career-section-content');
+    if (!section) return;
+
+    const line = section.querySelector('.timeline-line');
+    const items = gsap.utils.toArray('.timeline-item');
+
+    gsap.set([line, ...items], { autoAlpha: 0 });
+
+    const tl = gsap.timeline({
+      scrollTrigger: {
+        trigger: section,
+        start: 'top 60%',
+        once: true,
+      },
+    });
+
+    tl.to(line, {
+      autoAlpha: 1,
+      scaleY: 1,
+      duration: 1.5,
+      from: { scaleY: 0 },
+      ease: 'power2.out',
+    }).to(
+      items,
+      { autoAlpha: 1, y: 0, stagger: 0.3, from: { y: 50 }, ease: 'power3.out' },
+      '-=1.0'
+    );
+  });
+</script>

--- a/src/components/ui/ExperienceCard.astro
+++ b/src/components/ui/ExperienceCard.astro
@@ -1,0 +1,154 @@
+---
+// src/components/ui/ExperienceCard.astro
+import type { CollectionEntry } from 'astro:content';
+import Card from '@/components/ui/Card.astro';
+import ChipTech from '@/components/ui/ChipTech.astro';
+import { techIconMap } from '@/config/tech-icon-map';
+import {
+  IconPointFilled,
+  IconChevronDown,
+  IconFileText,
+} from '@tabler/icons-react'; // Importamos IconFileText
+
+interface Props {
+  experience: CollectionEntry<'career'>;
+}
+const { experience } = Astro.props;
+const {
+  title,
+  entity,
+  location,
+  startDate,
+  endDate,
+  contractType,
+  achievements,
+  techStack,
+} = experience.data;
+
+const formatDate = (date: Date) => new Date(date).getFullYear();
+---
+
+<div class="experience-card-wrapper group cursor-pointer">
+  <Card padding="lg" class="relative overflow-hidden">
+    <div class="halo-effect"></div>
+
+    <div class="relative z-10 flex flex-col">
+      <!-- Encabezado de la Tarjeta -->
+      <div class="flex items-start justify-between">
+        <div>
+          <h3 class="text-xl font-bold text-text-primary">{title}</h3>
+          <p class="mt-2 text-sm text-text-secondary">
+            {entity} &bull; {location}
+          </p>
+          <p class="text-text-secondary/70 mt-1 text-xs">
+            {formatDate(startDate)} - {
+              endDate ? formatDate(endDate) : 'Presente'
+            }
+          </p>
+        </div>
+
+        {
+          /* 
+          LA SOLUCIÓN: Usamos ChipTech para el tipo de contrato.
+          - `name="contract"`: Usamos una clave para buscar el color en `techColorMap`.
+          - `label={contractType}`: El texto real del contrato.
+          - `Icon={IconFileText}`: Un icono genérico para "contrato".
+          - `class="!px-2 !py-0.5"`: Ajustamos el padding para que sea un chip más pequeño.
+        */
+        }
+        {
+          contractType && (
+            <ChipTech
+              Icon={IconFileText}
+              name="contract"
+              label={contractType}
+              class="!px-2 !py-0.5"
+            />
+          )
+        }
+      </div>
+
+      <!-- Botón de Despliegue -->
+      <button
+        class="details-toggle mt-4 flex items-center gap-x-2 text-sm font-semibold text-text-secondary transition-colors hover:text-text-primary"
+      >
+        <span>{achievements.length} Logros Clave</span>
+        <IconChevronDown
+          className="h-4 w-4 transition-transform duration-300"
+        />
+      </button>
+
+      <!-- Contenido Desplegable (sin cambios) -->
+      <div class="details-container max-h-0 overflow-hidden">
+        <div class="details-content pt-6">
+          <div class="border-t border-border pt-6">
+            <h4
+              class="font-sans text-sm font-bold uppercase tracking-wider text-text-secondary"
+            >
+              Logros Clave
+            </h4>
+            <ul class="mt-4 space-y-3">
+              {
+                achievements.map((achievement) => (
+                  <li class="flex items-start gap-x-3">
+                    <IconPointFilled className="h-4 w-4 flex-shrink-0 text-text-secondary/50 mt-1" />
+                    <span class="text-sm text-text-secondary">
+                      {achievement}
+                    </span>
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+          {
+            techStack && techStack.length > 0 && (
+              <div class="mt-6">
+                <h4 class="font-sans text-sm font-bold uppercase tracking-wider text-text-secondary">
+                  Stack Tecnológico
+                </h4>
+                <div class="mt-4 flex flex-wrap gap-2">
+                  {techStack.map((tech) => {
+                    const Icon = techIconMap[tech.toLowerCase()];
+                    return Icon ? <ChipTech Icon={Icon} name={tech} /> : null;
+                  })}
+                </div>
+              </div>
+            )
+          }
+        </div>
+      </div>
+    </div>
+  </Card>
+</div>
+<!-- 3. El script de GSAP para la expansión. Es idéntico en espíritu al de ProjectCard. -->
+<script>
+  import gsap from 'gsap';
+  document
+    .querySelectorAll('.experience-card-wrapper')
+    .forEach((cardWrapper) => {
+      const toggle = cardWrapper.querySelector('.details-toggle');
+      const container = cardWrapper.querySelector('.details-container');
+      const content = cardWrapper.querySelector('.details-content');
+      const chevron = cardWrapper.querySelector('.details-toggle svg');
+      let isVisible = false;
+
+      if (!toggle || !container || !content || !chevron) return;
+
+      const tl = gsap.timeline({ paused: true });
+      tl.to(container, {
+        maxHeight: () => content.scrollHeight,
+        duration: 0.8,
+        ease: 'power3.inOut',
+      });
+
+      // La lógica de click ahora se aplica a todo el `cardWrapper`, no solo al botón.
+      cardWrapper.addEventListener('click', (e) => {
+        // Prevenimos que el clic en un enlace dentro de la tarjeta la active.
+        if (e.target instanceof HTMLElement && e.target.closest('a')) return;
+
+        isVisible = !isVisible;
+        gsap.to(chevron, { rotation: isVisible ? 180 : 0, duration: 0.4 });
+        isVisible ? tl.play() : tl.reverse();
+      });
+    });
+</script>

--- a/src/config/tech-icon-map.ts
+++ b/src/config/tech-icon-map.ts
@@ -1,0 +1,31 @@
+// src/config/tech-icon-map.ts
+import {
+  IconBrandReact,
+  IconBrandAstro,
+  IconBrandTypescript,
+  IconBrandTailwind,
+  IconHexagons,
+  IconBrandGit,
+  IconBrandDocker,
+  IconBrandGithub,
+  IconBrandMysql,
+  IconBrandVite,
+  IconBrandNodejs,
+} from '@tabler/icons-react';
+
+// Un mapa central para asociar un string de tecnología con su componente de icono.
+export const techIconMap: Record<string, astroHTML.JSX.Element> = {
+  react: IconBrandReact,
+  astro: IconBrandAstro,
+  typescript: IconBrandTypescript,
+  tailwind: IconBrandTailwind,
+  dotnet: IconHexagons,
+  git: IconBrandGit,
+  docker: IconBrandDocker,
+  github: IconBrandGithub,
+  mysql: IconBrandMysql,
+  vite: IconBrandVite,
+  'node.js': IconBrandNodejs,
+  aws: IconHexagons, // Usamos un icono genérico para la nube
+  postgresql: IconBrandMysql, // Reutilizamos el de MySQL
+};

--- a/src/content/career/02-digital-innovations.md
+++ b/src/content/career/02-digital-innovations.md
@@ -1,0 +1,14 @@
+---
+type: 'Work'
+title: 'Full Stack Developer'
+entity: 'Digital Innovations Inc'
+location: 'New York, NY'
+startDate: 2020-01-01
+endDate: 2022-01-01
+contractType: 'Full Time'
+achievements:
+  - 'Desarrollo y mantenimiento de múltiples aplicaciones web para clientes.'
+  - 'Liderazgo en iniciativas de diseño UX/UI para proyectos galardonados.'
+  - 'Mentoría de desarrolladores junior en mejores prácticas.'
+techStack: ['React', 'TypeScript', 'Node.js', 'GraphQL']
+---

--- a/src/content/career/techcorp.md
+++ b/src/content/career/techcorp.md
@@ -1,0 +1,14 @@
+---
+type: 'Work'
+title: 'Senior Full Stack Developer'
+entity: 'TechCorp Solutions'
+location: 'San Francisco, CA'
+startDate: 2022-01-01
+# endDate no se define para el trabajo actual
+contractType: 'Full Time'
+achievements:
+  - 'Arquitectura de infraestructura de microservicios para más de 10M de usuarios.'
+  - 'Reducción del tiempo de carga de la aplicación en un 60% mediante optimización.'
+  - 'Liderazgo de un equipo de 8 desarrolladores en un proceso de desarrollo ágil.'
+techStack: ['React', 'Node.js', 'TypeScript', 'AWS', 'Docker']
+---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,6 +13,23 @@ const projectsCollection = defineCollection({
   }),
 });
 
+// --- NUEVA COLECCIÓN "CAREER" ---
+const careerCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    type: z.enum(['Work', 'Education']), // Tipo de hito
+    title: z.string(), // Ej: "Senior Full Stack Developer" o "Ingeniería en Sistemas"
+    entity: z.string(), // Ej: "TechCorp Solutions" o "Universidad Nacional"
+    location: z.string(),
+    startDate: z.date(),
+    endDate: z.date().optional(), // Opcional para el trabajo actual
+    contractType: z.string().optional(), // Ej: "Full-Time", "Contract"
+    achievements: z.array(z.string()),
+    techStack: z.array(z.string()).optional(),
+  }),
+});
+
 export const collections = {
   projects: projectsCollection,
+  career: careerCollection, // <-- AÑADIDO
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 // src/pages/index.astro
 // RESPONSABILIDAD: Ensamblar las secciones de la página en el orden correcto.
 import About from '@/components/sections/About.astro';
+import Career from '@/components/sections/Career.astro';
 import Hero from '@/components/sections/Hero.astro';
 import Projects from '@/components/sections/Projects.astro';
 import Layout from '@/layouts/Layout.astro';
@@ -17,7 +18,7 @@ import Layout from '@/layouts/Layout.astro';
     <Hero />
     <About />
     <Projects />
-
+    <Career />
     <!-- Aquí irán las futuras secciones como <Contact /> -->
   </main>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,6 +62,24 @@
     --color-accent-magenta: #a33a8a; /* Una versión más brillante para el tema oscuro */
     --color-glow-border: rgba(255, 255, 255, 0.8);
   }
+  /* 
+    NUEVO: PATRÓN DE DISEÑO "HALO CARD"
+  */
+  .group:hover .halo-effect {
+    opacity: 1;
+  }
+  .halo-effect {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit; /* Hereda el radio de la tarjeta padre */
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.4s ease-in-out;
+    box-shadow:
+      inset 0 0 0 1.5px var(--color-accent-magenta),
+      0 0 25px 0 var(--color-accent-magenta);
+  }
 }
 
 /* --- 3. APLICACIÓN DE ESTILOS GLOBALES --- */
@@ -94,5 +112,26 @@
   .dark .glass-panel {
     box-shadow: var(--shadow-dark);
     border: 1px solid var(--border-dark);
+  }
+  .group:hover .halo-effect {
+    opacity: 1;
+  }
+  .halo-effect {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.4s ease-in-out;
+    /* 
+      LA CORRECCIÓN:
+      - Reemplazamos `--color-accent-magenta` por `--color-text-primary`.
+      - Esto crea el borde brillante de alto contraste (blanco/negro).
+      - La sombra exterior (`box-shadow`) ahora también usa este color para el "glow".
+    */
+    box-shadow:
+      inset 0 0 0 1.5px var(--color-text-primary),
+      0 0 25px 0 var(--color-text-primary);
   }
 }


### PR DESCRIPTION
This commit introduces the new, data--driven 'Career' section, which displays professional experience and education in a sophisticated, interactive timeline format.

- **Data Architecture (Content Collections):**
  - A new `career` collection has been added to `src/content/config.ts`, defining a strict schema for work and education entries. This ensures data integrity and decouples content from presentation.
  - A central `tech-icon-map.ts` has been created in `src/config/` to map technology strings to their corresponding icon components, creating a single source of truth for tech iconography.

- **New Component: `ExperienceCard.astro`:**
  - Creates a new, highly interactive `ExperienceCard.astro` component to display individual career milestones.
  - **Interactive Expansion:** Implements a 'click-to-reveal' functionality orchestrated with a GSAP Timeline. The card smoothly expands to show 'Key Achievements' and 'Tech Stack', using a 'Just-in-Time' height calculation for robustness.
  - **Unified UX:** The entire card is clickable, and the chevron icon animates to indicate the open/closed state, providing clear visual feedback.

- **Section Assembly (`Career.astro`):**
  - Creates the new `Career.astro` section component.
  - Fetches and sorts all entries from the `career` collection.
  - Renders the entries in a visually dynamic timeline layout, alternating card positions on desktop.
  - Implements a cinematic 'build-in' entrance animation with GSAP and ScrollTrigger, where the timeline 'draws' itself, followed by the staggered appearance of each experience card.

- **Design System Consistency:**
  - The `ExperienceCard` reuses the `.halo-effect` CSS component, ensuring its hover state is visually consistent with the `ProjectCard`.
  - The component is built by composing existing atomic components like `Card`, `ChipTech`, etc., adhering to our architectural principles.