### PR TITLE
feat(certifications): implement interactive certifications section

### DIFF
--- a/src/components/sections/Certifications.astro
+++ b/src/components/sections/Certifications.astro
@@ -1,0 +1,56 @@
+---
+// src/sections/Certifications.astro
+import { getCollection } from 'astro:content';
+import CertificationCard from '@/components/ui/CertificationCard.astro';
+
+const allCertifications = await getCollection('certifications');
+allCertifications.sort(
+  (a, b) => b.data.issueDate.valueOf() - a.data.issueDate.valueOf()
+);
+---
+
+<section id="certifications" class="py-24 md:py-32">
+  <div class="container-narrow certifications-section-content">
+    <h2 class="mb-16 text-center text-h2 font-bold text-text-primary">
+      // Certificaciones
+    </h2>
+
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
+      {
+        allCertifications.map((cert) => (
+          <CertificationCard certification={cert} />
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<script>
+  // Script de animación de entrada para la sección
+  import gsap from 'gsap';
+  import { ScrollTrigger } from 'gsap/ScrollTrigger';
+  gsap.registerPlugin(ScrollTrigger);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const section = document.querySelector('.certifications-section-content');
+    if (!section) return;
+
+    const cards = gsap.utils.toArray('.certification-card-wrapper');
+    gsap.set(cards, { autoAlpha: 0, y: 50 });
+
+    ScrollTrigger.create({
+      trigger: section,
+      start: 'top 70%',
+      onEnter: () => {
+        gsap.to(cards, {
+          autoAlpha: 1,
+          y: 0,
+          duration: 1.2,
+          stagger: 0.2,
+          ease: 'power3.out',
+        });
+      },
+      once: true,
+    });
+  });
+</script>

--- a/src/components/ui/CertificationCard.astro
+++ b/src/components/ui/CertificationCard.astro
@@ -1,0 +1,189 @@
+---
+// src/components/ui/CertificationCard.astro
+import type { CollectionEntry } from 'astro:content';
+import Card from '@/components/ui/Card.astro';
+import ChipTech from '@/components/ui/ChipTech.astro';
+import LevelBadge from '@/components/ui/LevelBadge.astro';
+import { techIconMap } from '@/config/tech-icon-map';
+import {
+  IconCertificate,
+  IconCalendar,
+  IconExternalLink,
+  IconPointFilled,
+  IconChevronDown,
+} from '@tabler/icons-react';
+interface Props {
+  certification: CollectionEntry<'certifications'>;
+}
+const { certification } = Astro.props;
+const {
+  title,
+  issuer,
+  category,
+  level,
+  issueDate,
+  expiryDate,
+  description,
+  keySkills,
+  // ¡IMPORTANTE! Asegúrate de que `techStack` se extrae de los datos.
+  techStack,
+  credentialId,
+  credentialUrl,
+} = certification.data;
+
+const formatDate = (date: Date) => new Date(date).getFullYear();
+---
+
+<div class="certification-card-wrapper group">
+  <Card padding="none" class="relative overflow-hidden">
+    <div class="halo-effect"></div>
+    <div class="relative z-10 flex flex-col p-6">
+      <!-- Encabezado (sin cambios) -->
+      <div class="flex items-center justify-between">
+        <div
+          class="flex items-center gap-x-3 text-sm font-semibold uppercase tracking-wider text-text-secondary"
+        >
+          <IconCertificate className="h-5 w-5" />
+          <span>{category}</span>
+        </div>
+        {
+          credentialUrl && (
+            <a
+              href={credentialUrl}
+              target="_blank"
+              class="text-text-secondary transition-colors hover:text-text-primary"
+              aria-label="Ver credencial"
+            >
+              <IconExternalLink className="h-5 w-5" />
+            </a>
+          )
+        }
+      </div>
+
+      <!-- Contenido Principal (sin cambios) -->
+      <div class="mt-4">
+        <h3 class="text-xl font-bold text-text-primary">{title}</h3>
+        <p class="mt-2 text-sm font-semibold text-text-secondary">{issuer}</p>
+        <div
+          class="text-text-secondary/80 mt-4 flex items-center gap-x-4 text-xs"
+        >
+          <div class="flex items-center gap-x-1.5">
+            <IconCalendar className="h-4 w-4" />
+            <span
+              >{formatDate(issueDate)} - {
+                expiryDate ? formatDate(expiryDate) : 'Sin Vencimiento'
+              }</span
+            >
+          </div>
+          <LevelBadge level={level} />
+        </div>
+        <p class="mt-4 text-base text-text-secondary" style="font-weight: 300;">
+          {description}
+        </p>
+      </div>
+
+      <!-- Botón de Despliegue (ahora más genérico) -->
+      <button
+        class="details-toggle mt-6 flex items-center gap-x-2 text-sm font-semibold text-text-secondary transition-colors hover:text-text-primary"
+      >
+        <span>Ver Detalles</span>
+        <IconChevronDown
+          className="h-4 w-4 transition-transform duration-300"
+        />
+      </button>
+
+      <!-- 
+        LA ARQUITECTURA CORRECTA Y COMPLETA:
+        Tanto "Key Skills" como "Tech Stack" viven DENTRO de `details-content`.
+      -->
+      <div class="details-container max-h-0 overflow-hidden">
+        <div class="details-content pt-4">
+          <!-- Sección Key Skills -->
+          <div class="border-t border-border pt-4">
+            <h4
+              class="font-sans text-sm font-bold uppercase tracking-wider text-text-secondary"
+            >
+              Key Skills
+            </h4>
+            <ul class="mt-4 space-y-3">
+              {
+                keySkills.map((skill: string) => (
+                  <li class="flex items-start gap-x-3">
+                    <IconPointFilled className="h-4 w-4 flex-shrink-0 text-text-secondary/50 mt-1" />
+                    <span class="text-sm text-text-secondary">{skill}</span>
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+
+          <!-- SECCIÓN "TECH STACK" RESTAURADA -->
+          {
+            techStack && techStack.length > 0 && (
+              <div class="mt-6">
+                <h4 class="font-sans text-sm font-bold uppercase tracking-wider text-text-secondary">
+                  Tech Stack
+                </h4>
+                <div class="mt-4 flex flex-wrap gap-2">
+                  {techStack.map((tech: string) => {
+                    const Icon = techIconMap[tech.toLowerCase()];
+                    return Icon ? <ChipTech Icon={Icon} name={tech} /> : null;
+                  })}
+                </div>
+              </div>
+            )
+          }
+        </div>
+      </div>
+
+      <!-- Footer de la Tarjeta (sin cambios) -->
+      <div
+        class="mt-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-text-secondary"
+      >
+        <span>ID: {credentialId || 'N/A'}</span>
+        {
+          credentialUrl && (
+            <a
+              href={credentialUrl}
+              target="_blank"
+              class="flex items-center gap-x-1.5 transition-colors hover:text-text-primary"
+            >
+              <span>View Credential</span>
+              <IconExternalLink className="h-3 w-3" />
+            </a>
+          )
+        }
+      </div>
+    </div>
+  </Card>
+</div>
+
+<!-- El script de GSAP no necesita ningún cambio. -->
+<script>
+  import gsap from 'gsap';
+  document
+    .querySelectorAll('.certification-card-wrapper')
+    .forEach((cardWrapper) => {
+      const toggle = cardWrapper.querySelector('.details-toggle');
+      const container = cardWrapper.querySelector('.details-container');
+      const content = cardWrapper.querySelector('.details-content');
+      const chevron = cardWrapper.querySelector('.details-toggle svg');
+      let isVisible = false;
+
+      if (!toggle || !container || !content || !chevron) return;
+
+      const tl = gsap.timeline({ paused: true });
+      tl.to(container, {
+        maxHeight: () => content.scrollHeight,
+        duration: 0.8,
+        ease: 'power3.inOut',
+      });
+
+      cardWrapper.addEventListener('click', (e) => {
+        if (e.target instanceof HTMLElement && e.target.closest('a')) return;
+        isVisible = !isVisible;
+        gsap.to(chevron, { rotation: isVisible ? 180 : 0, duration: 0.4 });
+        isVisible ? tl.play() : tl.reverse();
+      });
+    });
+</script>

--- a/src/components/ui/LevelBadge.astro
+++ b/src/components/ui/LevelBadge.astro
@@ -1,0 +1,49 @@
+---
+// src/components/ui/LevelBadge.astro
+import { IconStar, IconStarFilled } from '@tabler/icons-react';
+
+type Level = 'Expert' | 'Advanced' | 'Intermediate' | 'Fundamental';
+interface Props {
+  level: Level;
+}
+const { level } = Astro.props;
+
+const levelConfig = {
+  Expert: { color: 'bg-red-500/10 text-red-400 border-red-500/20', stars: 3 },
+  Advanced: {
+    color: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    stars: 2,
+  },
+  Intermediate: {
+    color: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    stars: 1,
+  },
+  Fundamental: {
+    color: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+    stars: 0,
+  },
+};
+
+const config = levelConfig[level];
+const totalStars = 3;
+---
+
+<div
+  class:list={[
+    'inline-flex items-center gap-x-2 rounded-pill border px-2 py-1 text-xs font-semibold',
+    config.color,
+  ]}
+>
+  <span>{level}</span>
+  <div class="flex items-center">
+    {
+      Array.from({ length: totalStars }).map((_, i) =>
+        i < config.stars ? (
+          <IconStarFilled className="h-3 w-3" />
+        ) : (
+          <IconStar className="h-3 w-3 opacity-50" />
+        )
+      )
+    }
+  </div>
+</div>

--- a/src/content/certifications/aws-solutions-architect.md
+++ b/src/content/certifications/aws-solutions-architect.md
@@ -1,0 +1,23 @@
+---
+title: 'AWS Solutions Architect - Professional'
+issuer: 'Amazon Web Services'
+category: 'Cloud'
+level: 'Expert'
+issueDate: 2023-01-01
+expiryDate: 2026-01-01
+description: 'Certificación avanzada para diseñar sistemas distribuidos en AWS, demostrando experiencia en arquitectura de nube, despliegue y optimización.'
+techStack: # Asegúrate de que este campo exista
+  - 'React'
+  - 'Astro'
+  - 'TypeScript'
+keySkills:
+  [
+    'Cloud Architecture',
+    'High Availability',
+    'Security',
+    'Cost Optimization',
+    'Migration',
+  ]
+credentialId: 'AWS-SAP-123456'
+credentialUrl: 'https://www.credly.com/...'
+---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -29,7 +29,25 @@ const careerCollection = defineCollection({
   }),
 });
 
+const certificationsCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    issuer: z.string(),
+    category: z.string(),
+    level: z.enum(['Expert', 'Advanced', 'Intermediate', 'Fundamental']),
+    issueDate: z.date(),
+    expiryDate: z.date().optional(),
+    description: z.string(),
+    keySkills: z.array(z.string()),
+    techStack: z.array(z.string()).optional(), // <-- CAMPO AÑADIDO Y OPCIONAL
+    credentialId: z.string().optional(),
+    credentialUrl: z.string().url().optional(),
+  }),
+});
+
 export const collections = {
   projects: projectsCollection,
-  career: careerCollection, // <-- AÑADIDO
+  career: careerCollection,
+  certifications: certificationsCollection,
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@
 // RESPONSABILIDAD: Ensamblar las secciones de la página en el orden correcto.
 import About from '@/components/sections/About.astro';
 import Career from '@/components/sections/Career.astro';
+import Certifications from '@/components/sections/Certifications.astro';
 import Hero from '@/components/sections/Hero.astro';
 import Projects from '@/components/sections/Projects.astro';
 import Badge from '@/components/ui/Badge.astro';
@@ -20,6 +21,7 @@ import Layout from '@/layouts/Layout.astro';
     <About />
     <Projects />
     <Career />
+    <Certifications />
     <div class="flex gap-4">
       <Badge text="Full Time" variant="accent" />
       <Badge text="Contract" variant="accent" />


### PR DESCRIPTION
This commit introduces the new, data-driven 'Certifications' section. It establishes a full content management pipeline using Astro's Content Collections and presents the data through a sophisticated, interactive card-based UI.

- **Data Architecture (Content Collections):**
  - **New `certifications` Collection:** A new, strictly-typed schema has been added to `src/content/config.ts`. It defines the data structure for each certification, including title, issuer, level, dates, key skills, and tech stack, ensuring data integrity.
  - **Content Creation:** The `src/content/certifications/` directory is now the source of truth for all certification data, fully decoupling content from presentation.

- **New UI Components:**
  - **`CertificationCard.astro`:** A new, highly interactive 'molecule' component has been created.
    - It composes existing atoms like `Card` and `ChipTech`.
    - Implements the same 'Halo Effect' on hover as the `ProjectCard` for visual consistency.
    - Features a 'click-to-reveal' functionality orchestrated with a GSAP Timeline, smoothly expanding to show 'Key Skills' and 'Tech Stack'. The animation logic is robust, using a 'Just-in-Time' height calculation.
  - **`LevelBadge.astro`:** A new atomic component created to display the certification level (e.g., 'Expert', 'Advanced') with a star rating system, providing a clear visual hierarchy.

- **Section Assembly (`Certifications.astro`):**
  - Creates the new `Certifications.astro` section component.
  - Fetches and sorts all entries from the `certifications` collection by issue date.
  - Renders the entries in a responsive two-column grid.
  - Implements a cinematic 'reveal' entrance animation for the section using GSAP and ScrollTrigger, staggering the appearance of each card.

- **Code Quality & Refinements:**
  - All new components are fully typed with TypeScript, following best practices for Astro components and props.
  - The `tech-icon-map.ts` has been centralized in `src/config/` to be used by all components that render technology stacks, adhering to the DRY principle.