### PR TITLE
feat(ui): implement final, interactive Footer section

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,17 @@
 {
-  // 1. Especificamos que Prettier es el formateador por defecto para TODOS los lenguajes.
+  // --- ASOCIACIÓN DE LENGUAJE ---
+  // Le decimos a VS Code que trate todos los archivos .css como `tailwindcss`.
+  // Esto activa el autocompletado y el linting correcto.
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
+
+  // --- FORMATEADOR POR DEFECTO ---
+  // Establecemos Prettier como el formateador por defecto para todo el workspace.
   "editor.defaultFormatter": "esbenp.prettier-vscode",
 
-  // 2. Activamos el formateo automático al guardar.
-  "editor.formatOnSave": true,
-
-  // 3. (Opcional pero recomendado) Si tienes conflictos, puedes ser más explícito.
+  // --- CONFIGURACIÓN POR LENGUAJE ---
+  // Somos explícitos para evitar conflictos entre extensiones.
   "[astro]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -15,13 +21,23 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[css]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-
-  // 4. Mantenemos la asociación de Tailwind para el autocompletado.
-  "files.associations": {
-    "*.css": "tailwindcss"
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "liveServer.settings.multiRootWorkspaceName": "portfolioLanding"
+
+  // --- CALIDAD DE CÓDIGO ---
+  "editor.formatOnSave": true, // Formatea automáticamente al guardar.
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit" // (Opcional) Si usas ESLint, esto arregla errores al guardar.
+  },
+
+  // --- CODIFICACIÓN DE ARCHIVOS ---
+  // Forzamos UTF-8 para evitar problemas con caracteres especiales.
+  "files.encoding": "utf8"
 }

--- a/src/components/sections/Footer.astro
+++ b/src/components/sections/Footer.astro
@@ -1,0 +1,193 @@
+---
+// src/sections/Footer.astro
+// ARQUITECTURA "TERMINAL DE PERFIL DINÁMICA":
+// Refactorizado para desacoplar los datos y refinar las interacciones.
+import Card from '@/components/ui/Card.astro';
+import Links from '@/components/ui/Links.astro';
+import SystemStatusLine from '@/components/ui/SystemStatusLine.astro';
+import {
+  IconCopy,
+  IconBrandGithub,
+  IconBrandLinkedin,
+} from '@tabler/icons-react';
+import { SITE_CONFIG } from '@/config/site'; // <-- Importamos nuestros datos
+
+const { profile, copyright } = SITE_CONFIG;
+---
+
+<footer id="footer" class="py-24 md:py-32">
+  <div class="container-narrow footer-section-content">
+    <Card padding="none" class="overflow-hidden">
+      <!-- Barra de Título -->
+      <div class="flex items-center gap-x-2 border-b border-border px-4 py-3">
+        <div class="h-3 w-3 rounded-full bg-red-500/90"></div>
+        <div class="h-3 w-3 rounded-full bg-yellow-500/90"></div>
+        <div class="h-3 w-3 rounded-full bg-green-500/90"></div>
+        <p class="ml-auto font-mono text-xs text-text-secondary">
+          ~/luciano.dev -- zsh
+        </p>
+      </div>
+
+      <!-- Contenido Principal -->
+      <div class="p-8">
+        <div
+          id="footer-command-line"
+          class="font-mono text-sm text-text-secondary"
+        >
+          <span class="text-text-primary">$</span>
+        </div>
+        <div
+          id="footer-content-grid"
+          class="mt-6 grid grid-cols-1 gap-12 opacity-0 md:grid-cols-3"
+        >
+          <!-- Columna 1: Perfil -->
+          <div class="space-y-4">
+            <h3 class="footer-heading">PERFIL</h3>
+            <p class="text-sm font-light text-text-secondary">
+              {profile.description}
+            </p>
+          </div>
+
+          <!-- Columna 2: Secciones -->
+          <div class="space-y-4">
+            <h3 class="footer-heading">SECCIONES</h3>
+            <Links
+              ulClass="flex-col !items-start !gap-y-2"
+              aClass="text-sm font-normal tracking-normal uppercase hover:text-[--color-accent-magenta]"
+            />
+          </div>
+
+          <!-- Columna 3: Contacto -->
+          <div class="space-y-4">
+            <h3 class="footer-heading">CONTACTO</h3>
+            <div class="flex flex-col items-start gap-4">
+              <button
+                class="contact-item group"
+                data-copy-text={profile.email}
+                aria-live="polite"
+              >
+                <IconCopy class="icon-base" strokeWidth={1.0} />
+                <span class="copy-text">Email</span>
+              </button>
+              <a
+                href={profile.githubUrl}
+                target="_blank"
+                class="contact-item group"
+              >
+                <IconBrandGithub class="icon-base" strokeWidth={1.0} />
+                <span>GitHub</span>
+              </a>
+              <a
+                href={profile.linkedinUrl}
+                target="_blank"
+                class="contact-item group"
+              >
+                <IconBrandLinkedin class="icon-base" strokeWidth={1.0} />
+                <span>LinkedIn</span>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <!-- Línea de Cierre -->
+        <div class="mt-12 border-t border-border pt-6">
+          <SystemStatusLine command="git status" />
+          <p class="mt-2 font-mono text-sm text-green-500">On branch main...</p>
+          <p class="text-text-secondary/70 mt-4 font-mono text-xs">
+            {copyright}
+          </p>
+        </div>
+      </div>
+    </Card>
+  </div>
+</footer>
+
+<!-- Estilos y Animación -->
+<style>
+  .footer-heading {
+    @apply font-mono text-lg font-normal uppercase tracking-wider text-text-primary;
+  }
+  .contact-item {
+    @apply flex items-center gap-x-3 font-mono text-sm text-text-secondary transition-colors duration-200;
+  }
+  .contact-item:hover {
+    color: var(--color-accent-magenta);
+  }
+</style>
+
+<script>
+  import gsap from 'gsap';
+  import { ScrollTrigger } from 'gsap/ScrollTrigger';
+  import { TextPlugin } from 'gsap/TextPlugin';
+
+  gsap.registerPlugin(ScrollTrigger, TextPlugin);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const section = document.querySelector('.footer-section-content');
+    const commandLine = document.getElementById('footer-command-line');
+    const contentGrid = document.getElementById('footer-content-grid');
+
+    if (!section || !commandLine || !contentGrid) return;
+
+    const tl = gsap.timeline({
+      scrollTrigger: {
+        trigger: section,
+        start: 'top 80%',
+        once: true,
+      },
+    });
+
+    tl.to(commandLine, {
+      duration: 1.5,
+      text: '$ cd ~/luciano-portfolio',
+      ease: 'none',
+    })
+      .to({}, { duration: 0.5 })
+      .to(commandLine, {
+        duration: 1.0,
+        text: '$ ls -F',
+        ease: 'none',
+        overwrite: 'auto',
+      })
+      .to(
+        contentGrid,
+        {
+          duration: 0.8,
+          opacity: 1,
+          ease: 'power3.out',
+        },
+        '-=0.5'
+      );
+
+    document.querySelectorAll('[data-copy-text]').forEach((button) => {
+      const textElement = button.querySelector('.copy-text');
+      if (!textElement) return;
+
+      const originalText = textElement.textContent;
+
+      button.addEventListener('click', () => {
+        const textToCopy = (button as HTMLElement).dataset.copyText;
+        if (!textToCopy) return;
+
+        navigator.clipboard
+          .writeText(textToCopy)
+          .then(() => {
+            // Feedback visual y de accesibilidad
+            textElement.textContent = '¡Copiado!';
+            button.classList.add('text-green-500');
+
+            // Usamos una timeline de GSAP para el "fade out" del estado de éxito
+            gsap.to(button, {
+              delay: 2,
+              duration: 0.5,
+              color: '', // GSAP es lo suficientemente inteligente para volver al color original
+              onComplete: () => {
+                textElement.textContent = originalText;
+              },
+            });
+          })
+          .catch((err) => console.error('Error al copiar:', err));
+      });
+    });
+  });
+</script>

--- a/src/components/ui/SystemStatusLine.astro
+++ b/src/components/ui/SystemStatusLine.astro
@@ -1,0 +1,14 @@
+---
+// src/components/ui/SystemStatusLine.astro
+// RESPONSABILIDAD: Mostrar una línea de texto estilizada como una salida de terminal.
+interface Props {
+  command: string;
+  class?: string;
+}
+const { command, class: className } = Astro.props;
+---
+
+<p class:list={['font-mono text-xs text-text-secondary', className]}>
+  <span class="text-text-primary/80">$</span>
+  {command}
+</p>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,11 @@
+// src/config/site.ts
+export const SITE_CONFIG = {
+  profile: {
+    description:
+      'Arquitecto de software Fullstack, especializado en la intersección de backend (.NET) y frontend (React) con un enfoque en UX/UI.',
+    email: 'meloclapsluciano@gmail.com',
+    githubUrl: 'https://github.com/luciano-meloclaps',
+    linkedinUrl: 'https://linkedin.com/in/luciano-melo-claps',
+  },
+  copyright: `Copyright © ${new Date().getFullYear()} Luciano Melo Claps. All Rights Reserved.`,
+};

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,35 +1,69 @@
 ---
 // src/layouts/Layout.astro
-// ARQUITECTURA "PARALLAX DE CAPAS":
-// Establece una estructura de capas global para crear un efecto de profundidad
-// donde el contenido parece flotar sobre un fondo de blueprint fijo.
+// RESPONSABILIDAD:
+// Ser la plantilla maestra y el "marco" de la aplicación. Define la estructura
+// global del documento, las meta etiquetas esenciales para SEO, y los
+// componentes persistentes de la UI como el Header.
+
+import { SEO } from 'astro-seo';
+import '@/styles/global.css';
 import ThemeManager from '@/components/modules/ThemeManager.astro';
 import Navbar from '@/components/modules/Navbar.astro';
 import MobileMenu from '@/components/modules/MobileMenu.astro';
-import '@/styles/global.css';
 
 interface Props {
   title: string;
+  description?: string;
 }
-const { title } = Astro.props;
+
+const {
+  title = 'Luciano Melo Claps | Software Developer',
+  description = 'Portfolio de un desarrollador Fullstack especializado en .NET y React, con un enfoque en arquitectura de software y diseño de experiencias de usuario.',
+} = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en" class="scroll-smooth">
+<html lang="es" class="scroll-smooth">
   <head>
-    <meta charset="UTF--8" />
-    <meta name="description" content="Portfolio de [Tu Nombre]" />
+    <!-- Meta etiquetas fundamentales -->
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+
+    <!-- 
+      Componente de SEO:
+      Gestiona automáticamente el título, la descripción, las etiquetas Open Graph
+      (para redes sociales) y más. Es una mejora masiva para el SEO.
+    -->
+    <SEO
+      title={title}
+      description={description}
+      openGraph={{
+        basic: {
+          title: title,
+          type: 'website',
+          image: '/og-image.png', // Debes crear esta imagen (1200x630px)
+        },
+      }}
+      twitter={{
+        card: 'summary_large_image',
+      }}
+    />
+
+    <!-- Favicon y Fuentes -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>{title}</title>
+
+    <!-- 
+      El ThemeManager DEBE estar en el <head> para prevenir el parpadeo (FOUC).
+      Es un script de bloqueo intencional.
+    -->
     <ThemeManager />
   </head>
   <body>
     <!-- 
       CAPA 1: EL FONDO DE BLUEPRINT FIJO
-      - `fixed inset-0`: Lo ancla a la pantalla completa.
-      - `z-[-1]`: Lo envía a la capa más profunda.
-      - Las clases `bg-*` aplican el patrón de cuadrícula.
+      - `fixed inset-0 z-[-1]`: Lo ancla a la pantalla y lo envía al fondo.
+      - `bg-[length:3rem_3rem]`: Controla el tamaño de la cuadrícula.
     -->
     <div
       class="fixed inset-0 z-[-1] bg-[length:3rem_3rem]"
@@ -37,18 +71,18 @@ const { title } = Astro.props;
         background-image: linear-gradient(var(--color-grid-line) 1px, transparent 1px),
                       linear-gradient(to right, var(--color-grid-line) 1px, transparent 1px);
       `
+      aria-hidden="true"
     >
     </div>
 
-    <!-- CONTROLES GLOBALES DE UI -->
+    <!-- Componentes de UI Globales -->
     <Navbar />
     <MobileMenu />
 
     <!-- 
       CAPA 2: EL CONTENIDO FLOTANTE
-      - El <slot /> renderizará todas nuestras secciones (Hero, About, etc.).
-      - Estas secciones se desplazarán normalmente, "flotando" sobre el fondo fijo.
+      - El <slot /> renderizará el contenido de cada página.
     -->
     <slot />
   </body>
-</html>
+</html>```

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import About from '@/components/sections/About.astro';
 import Career from '@/components/sections/Career.astro';
 import Certifications from '@/components/sections/Certifications.astro';
 import Contact from '@/components/sections/Contact.astro';
+import Footer from '@/components/sections/Footer.astro';
 import Hero from '@/components/sections/Hero.astro';
 import Projects from '@/components/sections/Projects.astro';
 import Badge from '@/components/ui/Badge.astro';
@@ -28,6 +29,7 @@ import Layout from '@/layouts/Layout.astro';
       <Badge text="Contract" variant="accent" />
     </div>
     <Contact />
+    <Footer />
     <!-- Aquí irán las futuras secciones como <Contact /> -->
   </main>
 </Layout>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -12,6 +12,7 @@ export default {
         'text-primary': 'var(--color-text-primary)',
         'text-secondary': 'var(--color-text-secondary)',
         border: 'var(--color-border)',
+        'accent-magenta': 'var(--color-accent-magenta)', // <-- AÑADIDO
       },
 
       // --- SINCRONIZACIÓN DE FUENTES ---


### PR DESCRIPTION
Closes #27 
Closes #44 

This commit introduces the complete, data-driven 'Footer' section, architected as a 'Terminal Session' panel. It serves as the final, thematic closing piece for the landing page experience.

- **New Section (`Footer.astro`):**
  - Creates the new `Footer.astro` section component, designed to simulate a realistic terminal window.
  - The component is built by composing our atomic `Card` component, ensuring visual consistency with the rest of the site's glassmorphism aesthetic.

- **Data Decoupling (`site.ts`):**
  - A new `src/config/site.ts` file has been created to act as a single source of truth for global site data (profile description, email, social links).
  - The `Footer` component is now fully decoupled from hardcoded content, fetching all its data from this central configuration file. This improves maintainability and adheres to the DRY principle.

- **Sophisticated UX/UI ('Terminal' Narrative):**
  - **Realistic Command Sequence:** The UI now simulates an authentic terminal session, featuring a sequence of recognizable commands (`cd`, `ls -F`, `git status`) to create an immersive narrative for developers.
  - **Refined Typography & Hierarchy:** The layout has been calibrated with a strong visual hierarchy, using `font-mono` and different text weights/colors to distinguish between commands, output, and status messages.
  - **Enhanced 'Copy to Clipboard' Interaction:**
    - The email address is now hidden from the UI for security against spam bots, with the real email stored in a `data-attribute`.
    - The interaction provides clear, accessible feedback: the text changes to '¡Copiado!', the color changes to green, and an `aria-live` attribute announces the change to screen readers.
    - The return-to-original-state animation is now handled by a GSAP timeline for robustness.

- **Final Design Polish:**
  - All icons within the footer have been calibrated to a `strokeWidth` of `1.0` for a finer, more precise aesthetic.
  - The copyright notice has been updated to be more professional and is now sourced from the central `site.ts` config.