### PR TITLE
refactor(ui): polish mobile menu, translate nav and clean up index

### DIFF
--- a/src/components/modules/MobileMenu.astro
+++ b/src/components/modules/MobileMenu.astro
@@ -1,100 +1,146 @@
 ---
-// src/components/MobileMenu.astro
-// ARQUITECTURA "PANEL ORQUESTADO":
-// Refinado para una alineación de texto equilibrada y profesional.
+// src/components/modules/MobileMenu.astro
 import Links from '@/components/ui/Links.astro';
+import { IconX } from '@tabler/icons-react';
 ---
 
 <div
   id="mobile-menu-container"
-  class="pointer-events-none fixed inset-0 z-40 opacity-0"
+  class="pointer-events-none fixed inset-0 z-[999] opacity-0"
   aria-hidden="true"
+  style="visibility: hidden;"
 >
-  <!-- El overlay de fondo -->
-  <div
-    id="mobile-menu-overlay"
-    class="bg-background/80 absolute inset-0 backdrop-blur-xl"
-  >
-  </div>
+  <!-- Fondo sólido -->
+  <div id="mobile-menu-overlay" class="absolute inset-0 bg-background"></div>
 
   <!-- 
-    El contenido del menú, sigue siendo un contenedor flex que centra todo.
+    BOTÓN DE CIERRE (ESTILO PROJECT CARD)
+    - bg-background/20: Vidrio sutil.
+    - backdrop-blur-md: Desenfoque.
+    - border-border: Borde consistente.
+    - rounded-small: Forma técnica.
   -->
-  <div class="relative z-10 flex h-full flex-col items-center justify-center">
-    {
-      /* 
-      LA SOLUCIÓN:
-      - `w-64`: Le damos al `<ul>` un ancho fijo de 256px.
-      - `text-left`: Forzamos a que todo el texto DENTRO del `<ul>` se alinee a la izquierda.
-      - `!items-start`: Sobrescribimos el `items-center` del `<ul>` para que los `<li>` se alineen al inicio.
-    */
-    }
-    <Links
-      ulClass="flex-col !gap-y-8 nav-links-mobile w-64 text-left !items-start"
-      aClass="!text-h3 !font-normal"
+  <button
+    id="mobile-menu-close-btn"
+    class="bg-background/20 hover:bg-background/40 text-secondary decorative-elem group pointer-events-auto absolute right-6 top-6 z-50 cursor-pointer rounded-small border border-border p-2 text-text-primary backdrop-blur-md transition-all duration-300 active:scale-95"
+    aria-label="Cerrar menú"
+  >
+    <IconX
+      className="h-6 w-6 transition-transform duration-300 group-hover:rotate-90"
+      strokeWidth={1.0}
     />
+  </button>
+
+  <!-- Contenido -->
+  <div class="relative z-10 flex h-full flex-col justify-start px-8 pt-32">
+    <div class="border-text-primary/20 decorative-elem mb-8 w-full border-t">
+    </div>
+
+    <!-- Título traducido -->
+    <h4
+      class="decorative-elem mb-8 font-mono text-xs uppercase tracking-widest text-text-secondary"
+    >
+      Navegación
+    </h4>
+
+    <div class="pointer-events-auto w-full">
+      <Links
+        ulClass="flex-col !gap-y-6 nav-links-mobile w-full text-left !items-start"
+        aClass="!text-3xl !font-light tracking-tight hover:text-accent-magenta transition-colors"
+      />
+    </div>
   </div>
 </div>
 
-<!-- El script de GSAP y la lógica de eventos no necesitan ningún cambio. -->
 <script>
   import gsap from 'gsap';
 
-  const container = document.getElementById('mobile-menu-container');
-  const overlay = document.getElementById('mobile-menu-overlay');
-  const links = gsap.utils.toArray('.nav-links-mobile li');
+  function initMobileMenu() {
+    const container = document.getElementById('mobile-menu-container');
+    const overlay = document.getElementById('mobile-menu-overlay');
+    const closeBtn = document.getElementById('mobile-menu-close-btn');
 
-  if (!container || !overlay || links.length === 0) {
-    console.error('Mobile menu elements not found.');
-  } else {
-    gsap.set(links, { y: 30, opacity: 0 });
+    if (!container || !overlay) return;
+
+    const decorativeElements = container.querySelectorAll('.decorative-elem');
+    const links = gsap.utils.toArray('.nav-links-mobile li') as HTMLElement[];
+
+    // Configuración Inicial
+    gsap.set(container, { autoAlpha: 0 });
+    gsap.set(links, { y: 20, opacity: 0 });
+    if (decorativeElements.length > 0) {
+      gsap.set(decorativeElements, { opacity: 0 });
+    }
 
     const tl = gsap.timeline({ paused: true });
 
-    tl.to(container, { duration: 0.3, autoAlpha: 1, ease: 'power2.out' }).to(
-      links,
-      {
-        duration: 0.3,
-        opacity: 1,
-        y: 0,
-        stagger: 0.15,
-        ease: 'power3.out',
-      },
-      '-=0.2'
-    );
+    // ANIMACIÓN ACELERADA (Snappy)
+    tl.to(container, { duration: 0.25, autoAlpha: 1, ease: 'power2.out' })
+      .to(
+        decorativeElements,
+        { duration: 0.3, opacity: 1, ease: 'power2.out' },
+        '-=0.1'
+      )
+      .to(
+        links,
+        {
+          duration: 0.2, // Más rápido (antes 0.3)
+          opacity: 1,
+          y: 0,
+          stagger: 0.05, // Cascada más rápida (antes 0.1)
+          ease: 'power3.out',
+        },
+        '-=0.15'
+      );
 
     let isMenuOpen = false;
 
     const openMenu = () => {
       if (isMenuOpen) return;
       isMenuOpen = true;
+
+      container.classList.remove('pointer-events-none');
+      container.classList.add('pointer-events-auto');
       container.setAttribute('aria-hidden', 'false');
-      document.body.classList.add('overflow-hidden');
+      document.body.style.overflow = 'hidden';
+
       tl.timeScale(1).play();
     };
 
     const closeMenu = () => {
       if (!isMenuOpen) return;
       isMenuOpen = false;
+
+      container.classList.remove('pointer-events-auto');
+      container.classList.add('pointer-events-none');
       container.setAttribute('aria-hidden', 'true');
-      document.body.classList.remove('overflow-hidden');
-      tl.timeScale(1.5).reverse();
+      document.body.style.overflow = '';
+
+      tl.timeScale(2.5).reverse();
+      document.dispatchEvent(new CustomEvent('menu-closed'));
     };
 
-    document.addEventListener('toggle-menu', () => {
+    const toggleHandler = () => {
       isMenuOpen ? closeMenu() : openMenu();
-    });
+    };
+
+    document.removeEventListener('toggle-menu', toggleHandler);
+    document.addEventListener('toggle-menu', toggleHandler);
 
     overlay.addEventListener('click', closeMenu);
 
-    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    links.forEach((link) => {
+      link.addEventListener('click', closeMenu);
+    });
 
-    const handleResize = (e: MediaQueryListEvent) => {
-      if (e.matches && isMenuOpen) {
+    if (closeBtn) {
+      closeBtn.onclick = (e) => {
+        e.stopPropagation();
         closeMenu();
-      }
-    };
-
-    mediaQuery.addEventListener('change', handleResize);
+      };
+    }
   }
+
+  document.addEventListener('astro:page-load', initMobileMenu);
+  document.addEventListener('DOMContentLoaded', initMobileMenu);
 </script>

--- a/src/components/modules/Navbar.astro
+++ b/src/components/modules/Navbar.astro
@@ -1,60 +1,48 @@
 ---
-// src/components/Navbar.astro
-// ARQUITECTURA "CENTRO DE COMANDO ADAPTATIVO":
-// Mantiene su animación de entrada y su estilo de vidrio, pero ahora se adapta
-// a pantallas móviles, mostrando un toggle en lugar de los enlaces.
+// src/components/modules/Navbar.astro
 import Links from '@/components/ui/Links.astro';
 import ThemeToggle from '@/components/modules/ThemeToggle.astro';
-import { IconMenu2, IconX } from '@tabler/icons-react';
+import { IconMenu, IconX } from '@tabler/icons-react';
 ---
 
 <header
   id="main-header"
-  class="-translate-y-fullopacity-0 fixed left-1/2 top-5 z-50 w-auto -translate-x-1/2"
+  class="pointer-events-auto fixed left-1/2 top-5 z-[100] w-auto -translate-x-1/2 -translate-y-full opacity-0"
   aria-label="Cabecera del sitio"
 >
   <nav
     id="navbar-container"
-    class="glass-panel flex items-center gap-x-8 rounded-medium border border-border px-20 py-2"
+    class="glass-panel flex items-center gap-x-8 rounded-medium border border-border px-6 py-3 shadow-lg md:px-12"
   >
-    <!-- Logo/Marca: Siempre visible -->
-    {
-      /* <div class="logo">
-      <a
-        href="/"
-        class="font-sans text-sm font-bold uppercase tracking-wider text-text-primary"
-      >
-        * marca*
-      </a>
-    </div>*/
-    }
-
-    <!-- Navegación de Escritorio: Oculta en móvil (`md:flex`) -->
-    <div class="hidden items-center gap-x-6 md:flex">
-      <Links />
+    <!-- 
+      NAVEGACIÓN DE ESCRITORIO (ESTILO CLEAN)
+      Aquí aplicamos la tipografía fina que te gustó.
+    -->
+    <div class="hidden items-center md:flex">
+      <Links
+        aClass="text-sm font-light tracking-widest text-text-secondary hover:text-text-primary hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.3)] dark:hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.1)]"
+      />
     </div>
 
-    <!-- Controles (ThemeToggle y Menú Móvil): Siempre visibles, pero el menú solo en móvil -->
+    <!-- Separador vertical sutil (Opcional, para separar nav de controles) -->
+    <div class="hidden h-4 w-px bg-border md:block"></div>
+
+    <!-- Controles -->
     <div class="flex items-center gap-x-2">
       <ThemeToggle />
 
-      <!-- Botón de Menú Móvil (El Despachador): Visible solo en móvil (`md:hidden`) -->
-      <!-- Botón de Menú Móvil (El Despachador) -->
+      <!-- Botón de Menú Móvil -->
       <button
         id="mobile-menu-toggle"
-        class="p-2 md:hidden"
+        class="cursor-pointer p-2 text-text-primary transition-colors hover:text-accent-magenta md:hidden"
         aria-label="Abrir o cerrar menú"
       >
-        <IconMenu2
-          className="h-6 w-6 text-text-primary"
-          id="icon-menu"
-          stroke={1}
-        />
-        <IconX
-          className="hidden h-6 w-6 text-text-primary"
-          id="icon-close"
-          stroke={1}
-        />
+        <div id="icon-menu" class="block">
+          <IconMenu className="h-6 w-6" strokeWidth={1} />
+        </div>
+        <div id="icon-close" class="hidden">
+          <IconX className="h-6 w-6" strokeWidth={1} />
+        </div>
       </button>
     </div>
   </nav>
@@ -62,40 +50,51 @@ import { IconMenu2, IconX } from '@tabler/icons-react';
 
 <script>
   import gsap from 'gsap';
-  import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
-  gsap.registerPlugin(ScrollTrigger);
-
-  document.addEventListener('DOMContentLoaded', () => {
+  function initNavbar() {
     const navbar = document.getElementById('main-header');
     const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
     const iconMenu = document.getElementById('icon-menu');
     const iconClose = document.getElementById('icon-close');
 
-    if (!navbar || !mobileMenuToggle || !iconMenu || !iconClose) return;
+    if (!navbar) return;
 
-    // La animación de entrada del Navbar con GSAP (tu código original, es perfecto).
+    // Animación de entrada
     gsap.to(navbar, {
       y: 0,
       autoAlpha: 1,
-      duration: 0.5,
-      ease: 'power3.out',
-      scrollTrigger: {
-        trigger: 'body',
-        start: 'top top-=-100px',
-        toggleActions: 'play none none reverse',
-      },
+      duration: 1.0,
+      ease: 'power4.out',
+      delay: 0.5,
     });
 
-    // Lógica del Despachador de Eventos.
-    mobileMenuToggle.addEventListener('click', () => {
-      // Crea y "grita" el evento personalizado.
-      const toggleEvent = new CustomEvent('toggle-menu');
-      document.dispatchEvent(toggleEvent);
+    if (mobileMenuToggle && iconMenu && iconClose) {
+      let isNavOpen = false;
 
-      // Lógica local para cambiar el icono de hamburguesa a 'X'.
-      iconMenu.classList.toggle('hidden');
-      iconClose.classList.toggle('hidden');
-    });
-  });
+      const updateIcons = (isOpen: boolean) => {
+        if (isOpen) {
+          iconMenu.classList.add('hidden');
+          iconClose.classList.remove('hidden');
+        } else {
+          iconMenu.classList.remove('hidden');
+          iconClose.classList.add('hidden');
+        }
+      };
+
+      mobileMenuToggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        isNavOpen = !isNavOpen;
+        updateIcons(isNavOpen);
+        document.dispatchEvent(new CustomEvent('toggle-menu'));
+      });
+
+      document.addEventListener('menu-closed', () => {
+        isNavOpen = false;
+        updateIcons(false);
+      });
+    }
+  }
+
+  document.addEventListener('astro:page-load', initNavbar);
+  document.addEventListener('DOMContentLoaded', initNavbar);
 </script>

--- a/src/components/ui/Links.astro
+++ b/src/components/ui/Links.astro
@@ -1,31 +1,33 @@
 ---
 // src/components/ui/Links.astro
-const navLinks = [
-  { href: '#about', label: 'About' },
-  { href: '#projects', label: 'Projects' },
-  { href: '#experience', label: 'Experience' },
-  { href: '#contact', label: 'Contact' },
+const links = [
+  { name: 'Acerca', href: '#about' },
+  { name: 'Proyectos', href: '#projects' },
+  { name: 'Carrera', href: '#career' },
+  { name: 'Contacto', href: '#contact' },
 ];
 
 interface Props {
-  ulClass?: string; // Clases para el contenedor <ul>
-  aClass?: string; // Clases para cada enlace <a>
+  ulClass?: string;
+  aClass?: string;
 }
+
 const { ulClass, aClass } = Astro.props;
 ---
 
-<ul class:list={['flex items-center gap-x-6', ulClass]}>
+<ul class:list={['flex items-center gap-x-8', ulClass]}>
   {
-    navLinks.map((link) => (
+    links.map((link) => (
       <li>
         <a
           href={link.href}
           class:list={[
-            'font-sans text-sm font-normal uppercase tracking-normal text-text-secondary transition-colors hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-text-primary',
+            // Base: Fuente técnica, transición suave
+            'font-sans text-sm uppercase tracking-wider text-text-secondary transition-all duration-300 ease-out hover:text-text-primary',
             aClass,
           ]}
         >
-          {link.label}
+          {link.name}
         </a>
       </li>
     ))

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,21 +15,11 @@ import Layout from '@/layouts/Layout.astro';
 
 <Layout title="[Tu Nombre] | Portfolio Profesional">
   <main>
-    <!-- 
-      SECUENCIA NARRATIVA CORRECTA:
-      Cada sección es un "hermano" del siguiente, no un "hijo".
-    -->
     <Hero />
     <About />
     <Projects />
     <Career />
-    <Certifications />
-    <div class="flex gap-4">
-      <Badge text="Full Time" variant="accent" />
-      <Badge text="Contract" variant="accent" />
-    </div>
     <Contact />
     <Footer />
-    <!-- Aquí irán las futuras secciones como <Contact /> -->
   </main>
 </Layout>


### PR DESCRIPTION
- Unify MobileMenu close button style with ProjectCard (glassmorphism).
- Translate navigation links to Spanish (Acerca, Proyectos, etc.).
- Optimize MobileMenu animation speed for a snappier feel.
- Fix Navbar state synchronization (listen to 'menu-closed' event).
- Remove debug/test labels from Index page.