### PR TITLE
fix(content): standardize categories and add missing icons

### DIFF
--- a/src/components/ui/CategoryBadge.astro
+++ b/src/components/ui/CategoryBadge.astro
@@ -4,7 +4,7 @@ import {
   IconBrain,
   IconCloud,
   IconCode,
-  IconMicrophone,
+  IconUsers,
   IconPalette,
   IconLanguage,
   IconCertificate,
@@ -25,9 +25,9 @@ const categoryConfig: Record<
 > = {
   IA: {
     icon: IconBrain,
-    // Indigo para coincidir con tech-colors (#6366F1)
+    // Violeta Neon
     colorClass:
-      'text-indigo-400 bg-indigo-500/10 border-indigo-500/20 shadow-[0_0_10px_rgba(99,102,241,0.15)]',
+      'text-violet-400 bg-violet-500/10 border-violet-500/20 shadow-[0_0_10px_rgba(167,139,250,0.15)]',
     label: 'Inteligencia Artificial',
   },
   Cloud: {
@@ -39,23 +39,23 @@ const categoryConfig: Record<
   },
   Development: {
     icon: IconCode,
-    // Emerald Green para coincidir con tech-colors (#10B981)
+    // Emerald/Teal Neon
     colorClass:
-      'text-emerald-400 bg-emerald-500/10 border-emerald-500/20 shadow-[0_0_10px_rgba(16,185,129,0.15)]',
-    label: 'Desarrollo',
+      'text-emerald-400 bg-emerald-500/10 border-emerald-500/20 shadow-[0_0_10px_rgba(52,211,153,0.15)]',
+    label: 'Development',
   },
   'Soft Skills': {
-    icon: IconMicrophone,
-    // Amber Gold para Soft Skills (#F59E0B)
+    icon: IconUsers,
+    // Orange Neon
     colorClass:
-      'text-amber-400 bg-amber-500/10 border-amber-500/20 shadow-[0_0_10px_rgba(245,158,11,0.15)]',
+      'text-orange-400 bg-orange-500/10 border-orange-500/20 shadow-[0_0_10px_rgba(251,146,60,0.15)]',
     label: 'Soft Skills',
   },
   Design: {
     icon: IconPalette,
-    // Pink para coincidir con tech-colors (#EC4899)
+    // Pink Neon
     colorClass:
-      'text-pink-500 bg-pink-500/10 border-pink-500/20 shadow-[0_0_10px_rgba(236,72,153,0.15)]',
+      'text-pink-400 bg-pink-500/10 border-pink-500/20 shadow-[0_0_10px_rgba(244,114,182,0.15)]',
     label: 'Diseño UX/UI',
   },
   Languages: {


### PR DESCRIPTION
This commit resolves two data consistency issues to ensure the certification filter and cards render correctly and uniformly.

- **Standardize Category Name:**
  - Audited all certification Markdown files in `src/content/certifications/`.
  - Replaced all instances of the category `'Desarrollo'` with the standardized English term `'Development'`.
  - This fixes the bug where two separate filter buttons were being generated for the same category.

- **Add Missing Icon:**
  - Updated `src/config/tech-icon-map.ts` to include a new entry for the `'soft skills'` category.
  - Mapped `'soft skills'` to the `IconUsers` component from Tabler Icons.
  - This resolves the visual bug where the 'Soft Skills' filter chip was rendered without an icon.